### PR TITLE
Add void to functions that take no parameters

### DIFF
--- a/carnival.c
+++ b/carnival.c
@@ -48,7 +48,7 @@ void avgPts(Coord a[3], Coord b[3], Coord result[3])
 /* This draws some mountains, which are very simple, so the animation	*/
 /* isn't slowed down.	*/
 
-void mountains()
+void mountains(void)
 {
 	Coord mnt1p[3] = {80, 50, 0 };
 	Coord mnt1b1[3] = {80, -1.0, -50 };

--- a/carnival.h
+++ b/carnival.h
@@ -40,7 +40,7 @@ void avgPts(Coord a[3], Coord b[3], Coord result[3]);
 /* This draws some mountains, which are very simple, so the animation	*/
 /* isn't slowed down.	*/
 
-void mountains();
+void mountains(void);
 
 /* The folowing draws the entire scene. It takes the current rotation 	*/
 /* of the ferris wheel and the number of points in the roller coaster	*/

--- a/coaster.c
+++ b/coaster.c
@@ -9,7 +9,7 @@
 /* don't have to be calculated each time it is drawn.  It returns the	*/
 /* number of points in the roller arrays.				*/
 
-int getCoasterPts()
+int getCoasterPts(void)
 {
 	int i = 0;
 	float a;

--- a/coaster.h
+++ b/coaster.h
@@ -23,7 +23,7 @@ extern Coord rollerout[350][3];        /* Coords for the outer rail */
 /* don't have to be calculated each time it is drawn.  It returns the	*/
 /* number of points in the roller arrays.				*/
 
-int getCoasterPts();
+int getCoasterPts(void);
 
 /* The following draws the struts of the roller coaster.	*/
 

--- a/main.c
+++ b/main.c
@@ -33,7 +33,7 @@ static GLint gCurrentIteration = 0;
 
 static GLdouble gStep = 0.1;
 
-static void dump()
+static void dump(void)
 {
 	fprintf(stderr, "gAnimating: %d gStyle: %d gRollPts: %d gCurrentCoaster: %d gRotation: %f\n", gAnimating, gStyle, gRollPts, gCurrentCoaster, gRotation);
 	fprintf(stderr, "Ferris View: (%f, %f, %f)\n", gFWV[0], gFWV[1], gFWV[2]);
@@ -41,7 +41,7 @@ static void dump()
 	fprintf(stderr, "**********\n");
 }
 
-static void Init()
+static void Init(void)
 {
 	gRollPts = getCoasterPts();
 
@@ -49,7 +49,7 @@ static void Init()
 	glEnable(GL_DEPTH_TEST);
 }
 
-static void Display()
+static void Display(void)
 {
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
@@ -62,7 +62,7 @@ static void Display()
 	glutSwapBuffers();
 }
 
-static void Idle()
+static void Idle(void)
 {
 	if (++gCurrentIteration < gThreshhold)
 	{

--- a/tent.c
+++ b/tent.c
@@ -6,7 +6,7 @@
 
 #include "tent.h"
 
-void tent()
+void tent(void)
 {
 	Coord v0[3] = {0.0, 0.0, 3.0 };
 	Coord v1[3] = {0.0, 0.0, 0.0 };

--- a/tent.h
+++ b/tent.h
@@ -9,6 +9,6 @@
 
 #include "carnival.h"
 
-void tent();
+void tent(void);
 
 #endif /* _TENT_ */


### PR DESCRIPTION
Fixes the warning "A function declaration without a prototype is deprecated in all versions of C"